### PR TITLE
Fixing the default listening interface

### DIFF
--- a/run
+++ b/run
@@ -20,4 +20,4 @@ fi
 
 # Launch
 echo "Launching on 127.0.0.1:$port"
-exec plackup -s Twiggy --workers=4 -0 127.0.0.1 -p $port -a ./bin/dns-api --access-log logs/access.$(date +%Y-%m-%d).log -E production
+exec plackup -s Twiggy --workers=4 --host 127.0.0.1 -p $port -a ./bin/dns-api --access-log logs/access.$(date +%Y-%m-%d).log -E production


### PR DESCRIPTION
Binding interface is specified by -o and not -0, but using long names for options is preferred in scripts