### PR TITLE
Add CORS response headers

### DIFF
--- a/lib/DNS/API.pm
+++ b/lib/DNS/API.pm
@@ -169,6 +169,10 @@ get '/:type/:domain/?' => sub {
     # Regardless of error/success we'll return JSON.
     content_type 'application/json';
 
+    # We'll add the CORS headers as well
+    header('Access-Control-Allow-Origin', '*')
+    header('Access-Control-Expose-Headers', '*')
+
     my $json;
 
     # Try to work out if we're being tested by a browser
@@ -205,6 +209,8 @@ get '/:type/:domain/?' => sub {
 get '/version/?' => sub {
 
     content_type 'application/json';
+    header('Access-Control-Allow-Origin', '*')
+    header('Access-Control-Expose-Headers', '*')
     my %result = ( version => $VERSION );
 
     my $json = JSON->new();


### PR DESCRIPTION
This PR adds the headers required to allow cross-origin requests in a browser environment (e.g. Ajax).

See also:

- [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)

    > Cross-Origin Resource Sharing (CORS) is a mechanism that uses additional HTTP headers to let a user agent gain permission to access selected resources from a server on a different origin (domain) than the site currently in use.

    > For requests without credentials, the server may specify [`Access-Control-Allow-Origin: *`], thereby allowing any origin to access the resource.

- [Fetch Standard §3.2.4. HTTP new-header syntax](https://fetch.spec.whatwg.org/#http-new-header-syntax)

    > For `Access-Control-Expose-Headers`, `Access-Control-Allow-Methods`, and `Access-Control-Allow-Headers` response headers the value `*` counts as a wildcard for requests without credentials.

Exposing all of the headers is what allows a client to monitor their limit over time.